### PR TITLE
Use `nix-portable` to allow using the devshell without installing DD-enabled nix globally

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -100,9 +100,84 @@
         "type": "github"
       }
     },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix-dynamic-derivations",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix-portable",
           "nix",
           "nixpkgs"
         ]
@@ -134,6 +209,72 @@
           "nixpkgs"
         ],
         "nixpkgs-stable": [
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1734279981,
+        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix_2": {
+      "inputs": {
+        "flake-compat": [
+          "nix-dynamic-derivations"
+        ],
+        "gitignore": [
+          "nix-dynamic-derivations"
+        ],
+        "nixpkgs": [
+          "nix-dynamic-derivations",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nix-dynamic-derivations",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1734279981,
+        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix_3": {
+      "inputs": {
+        "flake-compat": [
+          "nix-portable",
+          "nix"
+        ],
+        "gitignore": [
+          "nix-portable",
+          "nix"
+        ],
+        "nixpkgs": [
+          "nix-portable",
+          "nix",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nix-portable",
           "nix",
           "nixpkgs"
         ]
@@ -219,6 +360,57 @@
         "type": "github"
       }
     },
+    "nix-dynamic-derivations": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "flake-parts": "flake-parts_2",
+        "git-hooks-nix": "git-hooks-nix_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-23-11": "nixpkgs-23-11_2",
+        "nixpkgs-regression": "nixpkgs-regression_3"
+      },
+      "locked": {
+        "lastModified": 1740165078,
+        "narHash": "sha256-yqIVbJY7HkMjwZBoji0ptLuJpXUt94uk5zs0Dogt19c=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "d904921eecbc17662fef67e8162bd3c7d1a54ce0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "d904921eecbc17662fef67e8162bd3c7d1a54ce0",
+        "type": "github"
+      }
+    },
+    "nix-portable": {
+      "inputs": {
+        "defaultChannel": [
+          "nixpkgs"
+        ],
+        "nix": "nix_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744990698,
+        "narHash": "sha256-S9ymJqViggsviY12+z1shsax8ilE2r842zoPodl5vYk=",
+        "owner": "jaen",
+        "repo": "nix-portable",
+        "rev": "ce7229a8b279d706dbd0e20131fcbe4e50d40c6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jaen",
+        "ref": "improvements",
+        "repo": "nix-portable",
+        "type": "github"
+      }
+    },
     "nix2container": {
       "flake": false,
       "locked": {
@@ -233,6 +425,29 @@
         "owner": "nlewo",
         "repo": "nix2container",
         "type": "github"
+      }
+    },
+    "nix_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_5",
+        "flake-parts": "flake-parts_3",
+        "git-hooks-nix": "git-hooks-nix_3",
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-23-11": "nixpkgs-23-11_3",
+        "nixpkgs-regression": "nixpkgs-regression_4"
+      },
+      "locked": {
+        "lastModified": 1742824067,
+        "narHash": "sha256-rBPulEBpn4IiqkPsetuh7BRzT2iGCzZYnogTAsbrvhU=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "9cb662df7442a1e2c4600fb8ecb2ad613ebc5a95",
+        "type": "github"
+      },
+      "original": {
+        "id": "nix",
+        "ref": "2.27.1",
+        "type": "indirect"
       }
     },
     "nixpkgs": {
@@ -252,6 +467,38 @@
       }
     },
     "nixpkgs-23-11": {
+      "locked": {
+        "lastModified": 1717159533,
+        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      }
+    },
+    "nixpkgs-23-11_2": {
+      "locked": {
+        "lastModified": 1717159533,
+        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      }
+    },
+    "nixpkgs-23-11_3": {
       "locked": {
         "lastModified": 1717159533,
         "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
@@ -299,6 +546,38 @@
         "type": "github"
       }
     },
+    "nixpkgs-regression_3": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression_4": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1734359947,
@@ -316,6 +595,22 @@
       }
     },
     "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1734359947,
+        "narHash": "sha256-1Noao/H+N8nFB4Beoy8fgwrcOQLVm9o4zKW1ODaqK9E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "48d12d5e70ee91fe8481378e540433a7303dbf6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1741310760,
         "narHash": "sha256-aizILFrPgq/W53Jw8i0a1h1GZAAKtlYOrG/A5r46gVM=",
@@ -356,7 +651,9 @@
         "globset": "globset",
         "lix": "lix",
         "nix": "nix",
-        "nixpkgs": "nixpkgs_3"
+        "nix-dynamic-derivations": "nix-dynamic-derivations",
+        "nix-portable": "nix-portable",
+        "nixpkgs": "nixpkgs_4"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,17 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
+    nix-dynamic-derivations = {
+      url = "github:NixOS/nix?rev=d904921eecbc17662fef67e8162bd3c7d1a54ce0";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nix-portable ={ 
+      url = "github:jaen/nix-portable/improvements";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.defaultChannel.follows = "nixpkgs";
+    };
+
     nix.url = "github:hinshun/nix/2.27.1-fix-nix-missing-includes";
 
     lix.url = "github:lix-project/lix/2.91.1";
@@ -41,6 +52,10 @@
       };
 
       inherit (pkgs) lib;
+
+      nixDdPortable = pkgs.callPackage ./nix/packages/nix-portable {
+        inherit inputs;
+      };
 
       craneLib = inputs.crane.mkLib pkgs;
 
@@ -188,7 +203,9 @@
       packages.${system} = {
         inherit nix-ninja nix-ninja-task;
 
-        inherit (pkgs) nix;
+        inherit nixDdPortable;
+
+        nix = nixDdPortable;
 
         default = nix-ninja;
 
@@ -207,10 +224,31 @@
       devShells.${system}.default = craneLib.devShell {
         checks = inputs.self.checks.${system};
 
+        shellHook = ''
+          if command -v direnv_layout_dir 2>&1 >/dev/null; then
+            export NP_LOCATION="$(direnv_layout_dir)"
+            mkdir -p "$NP_LOCATION"
+
+            ADDITIONAL_CONFIG_FILE="$NP_LOCATION/nix-additional.conf"
+            rm $ADDITIONAL_CONFIG_FILE
+          fi
+
+          if command -v git 2>&1 >/dev/null; then
+            export NP_GIT="$(which git)"
+          fi
+
+          echo "max-jobs = auto" >> "$ADDITIONAL_CONFIG_FILE"
+          echo "cores = 0" >> "$ADDITIONAL_CONFIG_FILE"
+
+          export NP_CONF_ADDITIONAL_CONFIG="$ADDITIONAL_CONFIG_FILE"
+          export NP_CONF_ADDITIONAL_FEATURES="ca-derivations dynamic-derivations recursive-nix"
+        '';
+
         packages = with pkgs; [
           gnumake
           just
           meson
+          nixDdPortable
         ];
       };
     };

--- a/nix/packages/nix-portable/default.nix
+++ b/nix/packages/nix-portable/default.nix
@@ -1,0 +1,54 @@
+{ 
+  lib,
+  pkgs,
+  inputs,
+  stdenv,
+  runCommand,
+  ...
+}:
+  let
+    system = stdenv.system;
+
+    ddPackages = inputs.nix-dynamic-derivations.packages.${system};
+
+    nixDd = ddPackages.nix-everything;
+    nixDdStatic = ddPackages.nix-everything-static;
+
+    nixPortable = pkgs.callPackage inputs.nix-portable {
+      inherit lib pkgs;
+
+      buildSystem = system;
+      dataDirName = ".nix-dd-portable";
+
+      # The one from nixpkgs doesn't seem to work
+      proot = import "${ inputs.nix-portable }/proot/alpine.nix" { inherit pkgs; };
+
+      nix = nixDd;
+      nixStatic = nixDdStatic;
+      busybox = pkgs.pkgsStatic.busybox;
+      bubblewrap = pkgs.pkgsStatic.bubblewrap;
+      gnutar = pkgs.pkgsStatic.gnutar;
+      perl = pkgs.pkgsBuildBuild.perl;
+      xz = pkgs.pkgsStatic.xz;
+      zstd = pkgs.pkgsStatic.zstd;
+    };
+
+    wrapped = runCommand "nix-bin" {} ''
+      mkdir -p $out/bin
+
+      ln -s ${ nixPortable }/bin/nix-portable $out/bin/nix
+
+      ln -s $out/bin/nix $out/bin/nix-build  
+      ln -s $out/bin/nix $out/bin/nix-channel  
+      ln -s $out/bin/nix $out/bin/nix-collect-garbage  
+      ln -s $out/bin/nix $out/bin/nix-copy-closure  
+      ln -s $out/bin/nix $out/bin/nix-daemon  
+      ln -s $out/bin/nix $out/bin/nix-env  
+      ln -s $out/bin/nix $out/bin/nix-hash  
+      ln -s $out/bin/nix $out/bin/nix-instantiate  
+      ln -s $out/bin/nix $out/bin/nix-prefetch-url  
+      ln -s $out/bin/nix $out/bin/nix-shell  
+      ln -s $out/bin/nix $out/bin/nix-store
+    '';
+  in
+    wrapped


### PR DESCRIPTION
I wanted to try `nix-ninja`, but I also didn't want to switch `nix` on my machine to some alpha release globally, so I have tried to figure out a way to have it work with a chroot store and what finally worked was `nix-portable` (with a few fixes to have it work with new nixpkgs and additional features) — now I can run `nix build .#examples-nix` from the devshell and have it work out of the box. I tried to something more minimal by directly using bubblewrap, but I must've been missing something, as it was not enough.

I'll leave it as a draft for now, because it probably should not be merged as-is, but I figured I can at least start a discussion on improving developer experience on this, until DD is widely available.

Things to consider:
  * I have changed the default shell to use this wrapped `nix`, but maybe that's not desirable for some reason — I imagine there could be two shells and some way to select which one you want `direnv` to use,
  * I have branched off the lix branch, because it has at least started splitting the `flake.nix` into smaller chunks, so it was a bit easier to get a handle on it. I can rebase it on top of the `main` branch if you want, but I think it would be useful to split it even more, so it's more manageable (YMMV, but I usually use `flake.nix` for inputs only, import some `outputs.nix` for output definition and all devshells, packages and so on go into `nix` subdirectory, like the one I've added for `nix-portable`),
  * maybe the wrapper could be improved somewhat — for example it could sync the chroot store to your global one (after it finishes, or maybe somehow track what gets added?), so you can run whatever it built easily without any need for chroot/bubblewrap/whatnot on the resulting binaries.