### PR TITLE
Updating setup instructions and adding a warning for macOS users 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ system that outputs ninja like CMake, meson, premake, gn, etc.
 > unreleased version of Nix. Come help us get nix-ninja to be useful day-to-day
 > and working with an official Nix release!
 
+> [!WARNING]
+> macOS users: Currently not supported due to experimental feature propagation
+> issues during evaluation. You'll encounter `experimental Nix feature 'dynamic-derivations'
+> is disabled` errors when building examples, even with features enabled.
+> See [ca-derivations issue](https://github.com/NixOS/nix/issues/6065) and [multi-arch support](https://github.com/pdtpartners/nix-ninja/issues/14) tracking.
+
 - Parses `ninja.build` files and generates a derivation per compilation unit.
 - Stores build inputs & outputs in content-addressed derivations for granular
   and Nix-native incrementality.
@@ -34,11 +40,28 @@ system that outputs ninja like CMake, meson, premake, gn, etc.
 
 ## Getting started
 
-First you need to use [nix@d904921] and enable the following experimental
+First you need to use [nix@d904921]:
+```
+nix shell github:NixOS/nix/d904921
+```
+
+Verify by running:
+```
+$ nix --version
+nix (Nix) 2.27.0pre20250221_d904921
+```
+
+Then enable the following experimental
 features:
 
 ```sh
-experimental-features = ["nix-command" "dynamic-derivations" "ca-derivations" "recursive-nix"]
+export NIX_CONFIG="experimental-features = flakes nix-command dynamic-derivations ca-derivations recursive-nix"
+```
+
+Verify by running:
+```
+$ nix config show | grep experimental-features
+experimental-features = ca-derivations dynamic-derivations fetch-tree flakes nix-command recursive-nix
 ```
 
 Then you can try building the examples:


### PR DESCRIPTION
Example build on Mac will fail with:
```
         at /nix/store/nlcn8c2pix2fbhsdjv34mm3acgmavklq-source/mkMesonPackage.nix:62:4:
           61|
           62| in builtins.outputOf ninjaDrv.outPath normalizedTarget
             |    ^
           63|

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: experimental Nix feature 'dynamic-derivations' is disabled; add '--extra-experimental-features dynamic-derivations' to enable it
```