### PR TITLE
wip: try using libclang for dependency inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,9 +377,11 @@ name = "deps-infer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clang-sys",
  "clap",
  "include-graph",
  "n2",
+ "rayon",
  "shell-words",
  "tracing",
  "tracing-subscriber",
@@ -1004,6 +1016,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/crates/deps-infer/Cargo.toml
+++ b/crates/deps-infer/Cargo.toml
@@ -7,9 +7,11 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0"
+clang-sys = "1.8"
 clap = { version = "4.5", features = ["derive"] }
 include-graph = { git = "https://github.com/hinshun/igraph", branch = "performance-improvements" }
 n2 = { git = "https://github.com/hinshun/n2", branch = "feature/minimal-pub", default-features = false }
+rayon = "1.10"
 shell-words = "1.1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3.18", features = [

--- a/crates/deps-infer/src/clang_infer.rs
+++ b/crates/deps-infer/src/clang_infer.rs
@@ -1,0 +1,181 @@
+use anyhow::{anyhow, Result};
+use clang_sys::*;
+use std::collections::HashSet;
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_uint, c_void};
+use std::path::PathBuf;
+use std::ptr;
+
+struct VisitorData<'a> {
+    includes: &'a mut HashSet<PathBuf>,
+    tu: CXTranslationUnit,
+}
+
+pub fn retrieve_c_includes(cmdline: &str, files: Vec<PathBuf>) -> Result<Vec<PathBuf>> {
+    let mut all_includes = HashSet::new();
+
+    // Build compiler arguments from cmdline once
+    let args = build_clang_args(cmdline)?;
+
+    // Initialize clang index with diagnostics suppressed and reuse it
+    let index = unsafe { clang_createIndex(0, 0) };
+    if index.is_null() {
+        return Err(anyhow!("Failed to create clang index"));
+    }
+
+    // Try to parse all files in a single translation unit for better performance
+    if files.len() == 1 {
+        // Single file - use the existing approach
+        match parse_file_includes(index, &files[0], &args) {
+            Ok(file_includes) => all_includes.extend(file_includes),
+            Err(_) => {
+                // Skip files that can't be parsed
+            }
+        }
+    } else {
+        // Multiple files - could potentially batch them, but for now keep separate
+        // The real win would be to reuse parsed headers, but that's complex with current API
+        for file in files {
+            match parse_file_includes(index, &file, &args) {
+                Ok(file_includes) => all_includes.extend(file_includes),
+                Err(_) => {
+                    // Skip files that can't be parsed (e.g., missing generated headers)
+                    continue;
+                }
+            }
+        }
+    }
+
+    // Cleanup
+    unsafe {
+        clang_disposeIndex(index);
+    }
+
+    let mut result: Vec<PathBuf> = all_includes.into_iter().collect();
+    result.sort();
+    Ok(result)
+}
+
+fn build_clang_args(cmdline: &str) -> Result<Vec<CString>> {
+    // Split the command line using POSIX shell semantics
+    let mut cmdline_args =
+        shell_words::split(cmdline).map_err(|e| anyhow!("Invalid command line syntax: {}", e))?;
+
+    // Skip the compiler executable (first argument)
+    if !cmdline_args.is_empty() {
+        cmdline_args.remove(0);
+    }
+
+    // Filter out compilation-specific flags that libclang doesn't need
+    let mut filtered_args = Vec::new();
+    let mut i = 0;
+    while i < cmdline_args.len() {
+        let arg = &cmdline_args[i];
+
+        // Skip source files (they'll be passed separately to clang_parseTranslationUnit)
+        if arg.ends_with(".cpp")
+            || arg.ends_with(".c")
+            || arg.ends_with(".cc")
+            || arg.ends_with(".cxx")
+        {
+            i += 1;
+            continue;
+        }
+
+        // Keep all other arguments (include paths, defines, warnings, etc.)
+        filtered_args.push(arg.clone());
+        i += 1;
+    }
+
+    // Add flags to suppress system header diagnostics and use dependency mode
+    filtered_args.push("-w".to_string()); // Suppress all warnings
+    filtered_args.push("-Wno-error".to_string()); // Don't treat warnings as errors
+    filtered_args.push("-fsyntax-only".to_string()); // Skip code generation
+
+    // Convert to CStrings
+    filtered_args
+        .into_iter()
+        .map(|arg| CString::new(arg).map_err(|e| anyhow!("Invalid argument: {}", e)))
+        .collect()
+}
+
+fn parse_file_includes(
+    index: CXIndex,
+    file_path: &PathBuf,
+    args: &[CString],
+) -> Result<HashSet<PathBuf>> {
+    let mut includes = HashSet::new();
+
+    let file_str = file_path.to_str().unwrap();
+    let file_cstring = CString::new(file_str)?;
+
+    // Convert args to pointers
+    let arg_ptrs: Vec<*const c_char> = args.iter().map(|s| s.as_ptr()).collect();
+
+    // Minimal parsing - just enough to get include information
+    let tu = unsafe {
+        clang_parseTranslationUnit(
+            index,
+            file_cstring.as_ptr(),
+            arg_ptrs.as_ptr(),
+            arg_ptrs.len() as i32,
+            ptr::null_mut(),
+            0,
+            CXTranslationUnit_None,  // Try with no special flags first
+        )
+    };
+
+    if tu.is_null() {
+        return Err(anyhow!("Failed to parse translation unit for {}", file_str));
+    }
+
+    // Collect all inclusions using clang_getInclusions
+    let mut visitor_data = VisitorData {
+        includes: &mut includes,
+        tu,
+    };
+    unsafe {
+        clang_getInclusions(
+            tu,
+            inclusion_visitor,
+            &mut visitor_data as *mut VisitorData as *mut c_void,
+        );
+    }
+
+    // Cleanup
+    unsafe {
+        clang_disposeTranslationUnit(tu);
+    }
+
+    Ok(includes)
+}
+
+extern "C" fn inclusion_visitor(
+    file: CXFile,
+    _inclusion_stack: *mut CXSourceLocation,
+    _include_len: c_uint,
+    client_data: CXClientData,
+) {
+    if file.is_null() {
+        return;
+    }
+
+    let visitor_data = unsafe { &mut *(client_data as *mut VisitorData) };
+
+    unsafe {
+        // Check if this is a system header using clang's built-in functionality
+        let location = clang_getLocationForOffset(visitor_data.tu, file, 0);
+        if clang_Location_isInSystemHeader(location) != 0 {
+            return; // Skip system headers
+        }
+
+        let file_name = clang_getFileName(file);
+        let file_name_ptr = clang_getCString(file_name);
+        if !file_name_ptr.is_null() {
+            if let Ok(file_path_str) = CStr::from_ptr(file_name_ptr).to_str() {
+                visitor_data.includes.insert(PathBuf::from(file_path_str));
+            }
+        }
+        clang_disposeString(file_name);
+    }
+}

--- a/crates/deps-infer/src/lib.rs
+++ b/crates/deps-infer/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod c_include_parser;
+pub mod clang_infer;
 pub mod gcc_depfile;
 mod gcc_depfile_parser;
 mod gcc_include_parser;

--- a/crates/deps-infer/src/main.rs
+++ b/crates/deps-infer/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, Result};
 use clap::Parser;
-use deps_infer::{c_include_parser, gcc_depfile};
+use deps_infer::{c_include_parser, clang_infer, gcc_depfile};
 use n2::{canon, load, scanner};
 use std::{
     path::{Path, PathBuf},
@@ -64,14 +64,28 @@ fn main() -> Result<()> {
 
     match args.mode {
         Mode::Scan => {
-            let target_name = args.target.unwrap();
-
-            for target in targets {
-                if target.filename == target_name {
-                    return run_scan_mode(target);
+            match args.target {
+                Some(target_name) => {
+                    for target in targets {
+                        if target.filename == target_name {
+                            return run_scan_mode(target);
+                        }
+                    }
+                    Err(anyhow!("Failed to find target: {}", target_name))
+                }
+                None => {
+                    // Process all targets when no specific target is given
+                    for target in targets {
+                        let filename = target.filename.clone();
+                        println!("=== Scanning target: {} ===", filename);
+                        if let Err(e) = run_scan_mode(target) {
+                            eprintln!("Error scanning {}: {}", filename, e);
+                        }
+                        println!();
+                    }
+                    Ok(())
                 }
             }
-            Err(anyhow!("Failed to find target: {}", target_name))
         }
         Mode::Benchmark => run_benchmark_mode(targets),
         Mode::Correctness => run_correctness_mode(targets),
@@ -140,19 +154,16 @@ fn load_targets(build_filename: &str) -> Result<Vec<Target>> {
 }
 
 fn run_scan_mode(target: Target) -> Result<()> {
-    let gcc_includes = gcc_depfile::retrieve_c_includes(&target.cmdline)?;
-    println!("GCC depfile method:");
-    for include in gcc_includes {
+    let c_include_includes = c_include_parser::retrieve_c_includes(&target.cmdline, vec![target.filename.clone().into()])?;
+    println!("c_include_parser method:");
+    for include in c_include_includes {
         println!("{}", include.display());
     }
 
-    // Benchmark c_include_parser method
-    let c_includes = c_include_parser::retrieve_c_includes(
-        &target.cmdline,
-        vec![target.filename.clone().into()],
-    )?;
-    println!("C include parser method:");
-    for include in c_includes {
+    let clang_includes =
+        clang_infer::retrieve_c_includes(&target.cmdline, vec![target.filename.clone().into()])?;
+    println!("clang_infer method:");
+    for include in clang_includes {
         println!("{}", include.display());
     }
 
@@ -160,42 +171,43 @@ fn run_scan_mode(target: Target) -> Result<()> {
 }
 
 fn run_benchmark_mode(targets: Vec<Target>) -> Result<()> {
-    // Benchmark gcc_depfile method
-    let gcc_start = Instant::now();
-    for target in &targets {
-        gcc_depfile::retrieve_c_includes(&target.cmdline)?;
-    }
-    let gcc_duration = gcc_start.elapsed();
-    println!(
-        "GCC depfile method: {} milliseconds",
-        gcc_duration.as_millis()
-    );
-
+    println!("Benchmarking {} targets...", targets.len());
+    
     // Benchmark c_include_parser method
-    let c_start = Instant::now();
+    let c_include_start = Instant::now();
     for target in &targets {
-        c_include_parser::retrieve_c_includes(
-            &target.cmdline,
-            vec![target.filename.clone().into()],
-        )?;
+        let _ = c_include_parser::retrieve_c_includes(&target.cmdline, vec![target.filename.clone().into()]);
     }
-    let c_duration = c_start.elapsed();
+    let c_include_duration = c_include_start.elapsed();
     println!(
-        "C include parser method: {} milliseconds",
-        c_duration.as_millis()
+        "c_include_parser method: {} milliseconds",
+        c_include_duration.as_millis()
     );
 
-    // Calculate and display percentage difference
-    let gcc_ms = gcc_duration.as_millis() as f64;
-    let c_ms = c_duration.as_millis() as f64;
+    // Benchmark clang_infer method
+    let clang_start = Instant::now();
+    for target in &targets {
+        let _ = clang_infer::retrieve_c_includes(&target.cmdline, vec![target.filename.clone().into()]);
+    }
+    let clang_duration = clang_start.elapsed();
+    println!(
+        "clang_infer method: {} milliseconds",
+        clang_duration.as_millis()
+    );
 
-    if gcc_ms > 0.0 && c_ms > 0.0 {
-        let percentage_diff = (gcc_ms / c_ms) * 100.0;
-        if percentage_diff > 0.0 {
-            println!("C include parser is {percentage_diff:.2}% faster than GCC depfile method");
+    // Calculate and display performance comparison
+    let c_include_ms = c_include_duration.as_millis() as f64;
+    let clang_ms = clang_duration.as_millis() as f64;
+
+    if c_include_ms > 0.0 && clang_ms > 0.0 {
+        let ratio = c_include_ms / clang_ms;
+        if ratio > 1.0 {
+            println!("clang_infer is {:.2}x faster than c_include_parser", ratio);
         } else {
-            println!("C include parser is {percentage_diff:.2}% slower than GCC depfile method");
+            println!("c_include_parser is {:.2}x faster than clang_infer", 1.0 / ratio);
         }
+        
+        println!("Performance ratio (c_include_parser / clang_infer): {:.2}", ratio);
     }
 
     Ok(())
@@ -204,46 +216,46 @@ fn run_benchmark_mode(targets: Vec<Target>) -> Result<()> {
 fn run_correctness_mode(targets: Vec<Target>) -> Result<()> {
     let current_dir = std::env::current_dir()?;
     for target in targets {
-        let mut c_includes = c_include_parser::retrieve_c_includes(
+        let mut clang_includes = clang_infer::retrieve_c_includes(
             &target.cmdline,
             vec![target.filename.clone().into()],
         )?;
-        c_includes = normalize_paths(c_includes, &current_dir);
+        clang_includes = normalize_paths(clang_includes, &current_dir);
 
         let mut gcc_includes = gcc_depfile::retrieve_c_includes(&target.cmdline)?;
         gcc_includes = normalize_paths(gcc_includes, &current_dir);
 
         println!(
-            "{}: c {}, gcc {}",
+            "{}: clang {}, gcc {}",
             target.filename,
-            c_includes.len(),
+            clang_includes.len(),
             gcc_includes.len()
         );
 
-        // Find items in gcc_includes but not in c_includes
+        // Find items in gcc_includes but not in clang_includes
         let gcc_only: Vec<_> = gcc_includes
             .iter()
-            .filter(|path| !c_includes.contains(path))
+            .filter(|path| !clang_includes.contains(path))
             .collect();
 
         if !gcc_only.is_empty() {
             println!("Mismatch for {}", target.filename);
 
-            // Find items in c_includes but not in gcc_includes
-            let c_only: Vec<_> = c_includes
+            // Find items in clang_includes but not in gcc_includes
+            let clang_only: Vec<_> = clang_includes
                 .iter()
                 .filter(|path| !gcc_includes.contains(path))
                 .collect();
 
-            if !c_only.is_empty() {
-                println!("Found in c_includes but missing from gcc_includes:");
-                for path in c_only {
+            if !clang_only.is_empty() {
+                println!("Found in clang_includes but missing from gcc_includes:");
+                for path in clang_only {
                     println!("  + {}", path.display());
                 }
             }
 
             if !gcc_only.is_empty() {
-                println!("Found in gcc_includes but missing from c_includes:");
+                println!("Found in gcc_includes but missing from clang_includes:");
                 for path in gcc_only {
                     println!("  - {}", path.display());
                 }
@@ -253,10 +265,7 @@ fn run_correctness_mode(targets: Vec<Target>) -> Result<()> {
         }
     }
 
-    println!(
-        "c_include_parser is fully correct for {}",
-        current_dir.display()
-    );
+    println!("clang_infer is fully correct for {}", current_dir.display());
 
     Ok(())
 }

--- a/modules/flake/overlays.nix
+++ b/modules/flake/overlays.nix
@@ -21,6 +21,10 @@
         nativeBuildInputs = [
           self.pkg-config
         ];
+        buildInputs = [
+          self.libclang.lib
+        ];
+        LIBCLANG_PATH = "${self.libclang.lib}/lib";
       };
 
       # Build *just* the cargo dependencies, so we can reuse

--- a/modules/flake/packages.nix
+++ b/modules/flake/packages.nix
@@ -35,6 +35,12 @@
         meson
         taplo
       ];
+
+      buildInputs = with pkgs; [
+        libclang.lib
+      ];
+
+      LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
     };
   };
 }


### PR DESCRIPTION
Binding to libclang will let us avoid spawning a subprocess, i.e. methods tried in `gcc_depfile_parser.rs` but unfortunately it's quite slow:

```sh
$ cargo run -p deps-infer -- -C ~/git/nixos/nix/build --mode benchmark
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.32s
     Running `target/debug/deps-infer -C /home/hinshun/git/nixos/nix/build --mode benchmark`
Benchmarking 347 targets...
c_include_parser method: 5803 milliseconds
clang_infer method: 16357 milliseconds
c_include_parser is 2.82x faster than clang_infer
Performance ratio (c_include_parser / clang_infer): 0.35
```

It is necessary to have accurate dependency tracking, but c_include_parser is much faster and works for compiling NixOS/nix. I think we're going to have to end up with a "fast" and "precise" mode (defaulting to "fast' as it's likely to work for 90% projects). Perhaps we can use "precise" mode for the list of source files the user provides.