### PR TITLE
ci: Show full logs when building driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,6 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
       - name: Build NixOS test driver
-        run: nix build .#driver-${{ matrix.test }}
+        run: nix build -L .#driver-${{ matrix.test }}
       - name: Run integration tests
         run: nix run -L .#test-${{ matrix.test }}


### PR DESCRIPTION
This helps with debugging build failures that do not reproduce locally.