### PR TITLE
Remove some extraneous uses of `Path::to_string_lossy`

### DIFF
--- a/crates/nix-ninja-task/src/derived_file.rs
+++ b/crates/nix-ninja-task/src/derived_file.rs
@@ -93,9 +93,9 @@ impl fmt::Display for DerivedFile {
             StorePathOrPlaceholder::Placeholder(placeholder) => placeholder.render(),
         };
         if let Some(rel_path) = &self.rel_path {
-            write!(f, "{}", base_path.join(rel_path).to_string_lossy())
+            write!(f, "{:?}", base_path.join(rel_path))
         } else {
-            write!(f, "{}", base_path.to_string_lossy())
+            write!(f, "{:?}", base_path)
         }
     }
 }
@@ -121,8 +121,8 @@ pub fn create_symlinks(
 
         if !source_path.exists() {
             return Err(anyhow!(
-                "nix-ninja-task: symlink source does not exist: {}",
-                source_path.to_string_lossy()
+                "nix-ninja-task: symlink source does not exist: {:?}",
+                source_path
             ));
         }
 
@@ -132,8 +132,8 @@ pub fn create_symlinks(
 
         symlink(&source_path, &dest_path).map_err(|e| {
             anyhow!(
-                "Failed to create symlink from {} to {}: {}",
-                source_path.to_string_lossy(),
+                "Failed to create symlink from {:?} to {}: {}",
+                source_path,
                 dest_path.display(),
                 e
             )

--- a/crates/nix-ninja-task/src/patchelf.rs
+++ b/crates/nix-ninja-task/src/patchelf.rs
@@ -1,5 +1,5 @@
 use crate::derived_file::DerivedFile;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context as _, Result};
 use elf::endian::AnyEndian;
 use elf::ElfBytes;
 use std::fs;
@@ -74,7 +74,10 @@ fn compute_new_rpath(store_dir: &Path, elf_path: &Path) -> Result<Option<Vec<Str
             continue;
         };
 
-        let lib_str = lib_dir.to_string_lossy().to_string();
+        let lib_str = lib_dir
+            .to_str()
+            .context("Library directiory was not UTF-8")?
+            .to_owned();
         if !new_rpath.contains(&lib_str) {
             new_rpath.push(lib_str);
             path_added = true;

--- a/crates/nix-ninja/src/cli.rs
+++ b/crates/nix-ninja/src/cli.rs
@@ -1,7 +1,7 @@
 use crate::build::{self, BuildConfig};
 use crate::local;
 use crate::subtool::dynamic_task;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context as _, Result};
 use clap::Parser;
 use harmonia_store_core::store_path::StoreDir;
 use nix_ninja_task::derived_file::DerivedFile;
@@ -131,7 +131,9 @@ fn build(cli: &Cli, build_dir: &Path) -> Result<DerivedFile> {
     };
 
     build::build(
-        &cli.build_filename.to_string_lossy(),
+        cli.build_filename
+            .to_str()
+            .context("Filename was not valid UTF-8")?,
         cli.targets.clone(),
         config,
     )

--- a/crates/nix-ninja/src/task.rs
+++ b/crates/nix-ninja/src/task.rs
@@ -653,9 +653,8 @@ fn build_dynamic_task_derivation(
         b"out"[..].into(),
         Placeholder::standard_output(&OutputName::from_str("out")?)
             .render()
-            .to_string_lossy()
-            .to_string()
-            .into_bytes()
+            .into_os_string()
+            .into_encoded_bytes()
             .into(),
     );
 
@@ -789,10 +788,12 @@ pub fn which_store_path(store_dir: &StoreDir, binary_name: &str) -> Result<Store
     let store_path_dir = canonical_path
         .parent() // Get bin/ directory
         .and_then(|p| p.parent()) // Get the store path ($out)
-        .ok_or_else(|| anyhow!("Cannot determine store path from binary: {}", binary_name))?;
+        .ok_or_else(|| anyhow!("Cannot determine store path from binary: {}", binary_name))?
+        .to_str()
+        .context("Path was not valid UTF-8")?;
 
     store_dir
-        .parse(&store_path_dir.to_string_lossy())
+        .parse(store_path_dir)
         .context("Failed to parse store path")
 }
 
@@ -822,7 +823,10 @@ fn new_opaque_file(
     path: PathBuf,
 ) -> Result<DerivedFile> {
     let relative_path = relative_from(&path, build_dir).unwrap_or(path);
-    let mut path = relative_path.to_string_lossy().into_owned();
+    let mut path = relative_path
+        .to_str()
+        .context("Path was not valid UTF-8")?
+        .to_owned();
     canon::canonicalize_path(&mut path);
 
     let canonical_path = fs::canonicalize(&path)?;
@@ -881,7 +885,8 @@ pub fn discover_c_includes(
         if let Ok(relative) = include.strip_prefix(AsRef::<Path>::as_ref(store_dir)) {
             if let Some(hash_path) = relative.components().next().map(|c| c.as_os_str()) {
                 let full_path = AsRef::<Path>::as_ref(store_dir).join(hash_path);
-                let store_path: StorePath = store_dir.parse(&full_path.to_string_lossy())?;
+                let store_path: StorePath =
+                    store_dir.parse(full_path.to_str().context("Path was not valid UTF-8")?)?;
                 discovered_store_paths.push(store_path);
                 continue;
             }


### PR DESCRIPTION
In many cases where the code was using `to_string_lossy`, it should have been failing if any loss was required. Using `to_str` and managing the result is more correct.

Also, when printing there are useful debug prints, which will give more information.