### PR TITLE
actions: Use install-nix-action

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,8 +1,8 @@
 runs:
   using: composite
   steps:
-    - uses: DeterminateSystems/nix-installer-action@v19
+    - uses: cachix/install-nix-action@v31
       with:
-        extra-conf: |-
-          extra-experimental-features = dynamic-derivations ca-derivations recursive-nix
+        extra_nix_config: |-
+          extra-experimental-features = nix-command flakes dynamic-derivations ca-derivations
     - uses: DeterminateSystems/magic-nix-cache-action@v13


### PR DESCRIPTION
There seems to be an upstream issue building recent nix within older versions with this configuration.

Updating the determinate nix installer would use determinate nix, so switch to the cachix install-nix-action to use recent upstream nix.