### PR TITLE
Use install-nix-action and hestia

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -5,4 +5,4 @@ runs:
       with:
         extra_nix_config: |-
           extra-experimental-features = nix-command flakes dynamic-derivations ca-derivations
-    - uses: DeterminateSystems/magic-nix-cache-action@v13
+    - uses: Mic92/hestia@v2

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,8 +1,8 @@
 runs:
   using: composite
   steps:
-    - uses: DeterminateSystems/nix-installer-action@v19
+    - uses: cachix/install-nix-action@v31
       with:
-        extra-conf: |-
-          extra-experimental-features = dynamic-derivations ca-derivations recursive-nix
+        extra_nix_config: |-
+          extra-experimental-features = nix-command flakes dynamic-derivations ca-derivations
     - uses: DeterminateSystems/magic-nix-cache-action@v13

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -1,0 +1,41 @@
+# Garbage collection for the hestia binary cache.
+#
+# GC must run on the default branch: a PR job's cache scope is read-only
+# towards the default branch and dies with the PR, but the default-branch
+# scope grows forever without GC.
+name: Cache GC
+
+# GC handles concurrent pushes, but not a concurrent GC. Queue manual
+# runs behind the nightly one instead of overlapping it.
+concurrency:
+  group: hestia-gc
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Daily, off-peak (UTC).
+    - cron: "23 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Plan only; do not repack, touch, or delete anything.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  gc:
+    runs-on: ubuntu-latest
+    permissions:
+      # REST cache deletes need actions:write.
+      actions: write
+      contents: read
+    steps:
+      - uses: Mic92/hestia@v2
+      - name: Run garbage collection
+        run: |
+          "$HESTIA_BIN" gc ${{ inputs.dry-run && '--dry-run' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
There seems to be an upstream issue building recent nix within older
versions with this configuration.

Updating the determinate nix installer would use determinate nix,
so switch to the cachix install-nix-action to use recent upstream nix.

Also, replace `DeterminateSystems/magic-nix-cache-action` with
`Mic92/hestia`, a Nix binary cache backed by the GitHub Actions
cache: chunk-level dedup, few large cache entries instead of one per
store path, and no rate-limit issues. No accounts or secrets needed.